### PR TITLE
feat: 카카오 로그인 code→token 교환 엔드포인트 추가

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     GOOGLE_IOS_CLIENT_ID: str = ""
     KAKAO_REST_API_KEY: str = ""
     KAKAO_NATIVE_APP_KEY: str = ""
+    KAKAO_CLIENT_SECRET: str = ""
     APPLE_CLIENT_ID: str = ""
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379

--- a/app/users/auth_router.py
+++ b/app/users/auth_router.py
@@ -2,9 +2,11 @@ import secrets
 import random
 import logging
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.response import success
 from app.core.observability import posthog_client
@@ -92,7 +94,7 @@ def login(user_data: schemas.UserLogin, db: Session = Depends(get_db)):
                                properties={"provider": "email"})
     is_fbti_complete = user.fbti_type is not None
     is_profile_complete = user.age_group is not None
-    return success({"accessToken": access_token, "refreshToken": refresh_token, "tokenType": "bearer", "isFbtiComplete": is_fbti_complete, "isProfileComplete": is_profile_complete})
+    return success({"accessToken": access_token, "refreshToken": refresh_token, "tokenType": "bearer", "isFbtiComplete": is_fbti_complete, "isProfileComplete": is_profile_complete, "nickname": user.nickname or ""})
 
 
 @router.post("/auth/google", summary="구글 로그인", responses=_200({"accessToken": "eyJ...", "tokenType": "bearer", "isNewUser": False, "isProfileComplete": True}))
@@ -118,6 +120,41 @@ def google_login(body: schemas.GoogleLoginRequest, db: Session = Depends(get_db)
 @router.post("/auth/kakao", summary="카카오 로그인", responses=_200({"accessToken": "eyJ...", "tokenType": "bearer", "isNewUser": False, "isProfileComplete": True}))
 def kakao_login(body: schemas.KakaoLoginRequest, db: Session = Depends(get_db)):
     payload = _verify_kakao_token(body.id_token)
+    info = _extract_social_info("kakao", payload)
+    if not info["social_id"]:
+        raise HTTPException(status_code=400, detail="카카오 토큰에서 유저 정보를 가져올 수 없습니다.")
+    user, is_new_user = _social_login_or_signup(db, "kakao", info["social_id"],
+                                                 nickname=info["nickname"], profile_img=info["profile_img"])
+    access_token = create_access_token(data={"sub": str(user.user_id)})
+    refresh_token = create_refresh_token(user.user_id)
+    if is_new_user and posthog_client:
+        posthog_client.capture(distinct_id=str(user.user_id), event="user_signed_up", properties={"provider": "kakao"})
+    if posthog_client:
+        posthog_client.capture(distinct_id=str(user.user_id), event="user_logged_in", properties={"provider": "kakao"})
+    is_profile_complete = user.age_group is not None
+    is_fbti_complete = user.fbti_type is not None
+    return success({"accessToken": access_token, "refreshToken": refresh_token, "tokenType": "bearer", "isNewUser": is_new_user, "isProfileComplete": is_profile_complete, "isFbtiComplete": is_fbti_complete, "nickname": user.nickname or ""})
+
+
+@router.post("/auth/kakao/code", summary="카카오 로그인 (code → token 교환)", responses=_200({"accessToken": "eyJ...", "tokenType": "bearer", "isNewUser": False, "isProfileComplete": True}))
+def kakao_code_login(body: schemas.KakaoCodeLoginRequest, db: Session = Depends(get_db)):
+    token_res = httpx.post(
+        "https://kauth.kakao.com/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": settings.KAKAO_REST_API_KEY,
+            "client_secret": settings.KAKAO_CLIENT_SECRET,
+            "redirect_uri": body.redirect_uri,
+            "code": body.code,
+        },
+    )
+    if token_res.status_code != 200:
+        logger.error(f"[카카오 code 교환 실패] {token_res.text}")
+        raise HTTPException(status_code=401, detail="카카오 인가 코드 교환에 실패했습니다.")
+    id_token = token_res.json().get("id_token")
+    if not id_token:
+        raise HTTPException(status_code=401, detail="카카오 토큰 응답에 id_token이 없습니다.")
+    payload = _verify_kakao_token(id_token)
     info = _extract_social_info("kakao", payload)
     if not info["social_id"]:
         raise HTTPException(status_code=400, detail="카카오 토큰에서 유저 정보를 가져올 수 없습니다.")

--- a/app/users/schemas.py
+++ b/app/users/schemas.py
@@ -53,6 +53,10 @@ class GoogleLoginRequest(BaseModel):
 class KakaoLoginRequest(BaseModel):
     id_token: str
 
+class KakaoCodeLoginRequest(BaseModel):
+    code: str
+    redirect_uri: str
+
 class AppleLoginRequest(BaseModel):
     id_token: str
 


### PR DESCRIPTION
## Summary
- `POST /api/auth/kakao/code` 엔드포인트 추가
- 프론트에서 카카오 리다이렉트로 받은 `code`와 `redirect_uri`를 넘기면, 서버가 카카오 토큰 엔드포인트를 호출해 `id_token`으로 교환 후 기존 검증 로직에 태움
- 응답 스펙은 기존 `POST /api/auth/kakao`와 동일 (`accessToken`, `refreshToken`, `isNewUser`, `isProfileComplete`, `isFbtiComplete`, `nickname`)
- `KAKAO_CLIENT_SECRET` 환경변수 추가 (서버 `.env`에 카카오 개발자 콘솔 Client Secret 값 추가 필요)

## 요청 스펙
```json
POST /api/auth/kakao/code
{ "code": "카카오_인가_코드", "redirect_uri": "https://도메인/auth/callback" }
```

## 환경변수
서버 `.env`에 아래 값 추가 필요:
```
KAKAO_CLIENT_SECRET=카카오_개발자콘솔_Client_Secret
```

## Test plan
- [ ] 카카오 리다이렉트 방식으로 code 발급 후 `POST /api/auth/kakao/code` 호출 → 정상 토큰 응답 확인
- [ ] 잘못된 code 전달 시 401 응답 확인
- [ ] 기존 `POST /api/auth/kakao` (id_token 방식) 정상 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)