### PR TITLE
feat: CORS 허용 origin에 Vercel 도메인 추가

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,3 +1,9 @@
+map $http_origin $cors_origin {
+    "https://ttobaba-d8859.web.app"          $http_origin;
+    "https://web-ivory-seven-70.vercel.app"  $http_origin;
+    default                                   "";
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -45,8 +51,6 @@ server {
         proxy_hide_header 'Access-Control-Allow-Methods';
         proxy_hide_header 'Access-Control-Allow-Headers';
         proxy_hide_header 'Access-Control-Allow-Credentials';
-
-        set $cors_origin "https://ttobaba-d8859.web.app";
 
         # Preflight(OPTIONS): 허용 헤더에 Authorization 포함 필수
         if ($request_method = 'OPTIONS') {


### PR DESCRIPTION
## Summary
- nginx CORS 설정을 `map` 디렉티브 기반으로 변경해 다중 origin 지원
- `https://web-ivory-seven-70.vercel.app` 추가
- 최종 배포 도메인 확정 시 `map` 블록에 한 줄만 추가하면 됨

## 허용 origin 목록
```
https://ttobaba-d8859.web.app
https://web-ivory-seven-70.vercel.app
```

## Test plan
- [ ] Vercel 도메인에서 API 호출 시 CORS 오류 없음 확인
- [ ] 기존 Firebase 도메인(`ttobaba-d8859.web.app`) 정상 동작 유지 확인
- [ ] 허용되지 않은 origin은 `Access-Control-Allow-Origin` 헤더 미포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)