### PR TITLE
fix: 구글 로그인 웹용 클라이언트 ID 추가

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
     GOOGLE_CLIENT_ID: str = ""
     GOOGLE_IOS_CLIENT_ID: str = ""
+    GOOGLE_WEB_CLIENT_ID: str = ""
     KAKAO_REST_API_KEY: str = ""
     KAKAO_NATIVE_APP_KEY: str = ""
     KAKAO_CLIENT_SECRET: str = ""

--- a/app/users/router.py
+++ b/app/users/router.py
@@ -46,6 +46,8 @@ def _verify_google_token(id_token: str) -> dict:
         audiences = [settings.GOOGLE_CLIENT_ID]
         if settings.GOOGLE_IOS_CLIENT_ID:
             audiences.append(settings.GOOGLE_IOS_CLIENT_ID)
+        if settings.GOOGLE_WEB_CLIENT_ID:
+            audiences.append(settings.GOOGLE_WEB_CLIENT_ID)
         return google_id_token.verify_oauth2_token(
             id_token, google_requests.Request(), audiences
         )


### PR DESCRIPTION
## 원인
웹용 Google OAuth 클라이언트 ID(`672840096126-eo1g05o7l02tt7fhdb81hlq4nresk6bl`)가 백엔드 audiences 목록에 없어서 "Token has wrong audience" 오류 발생.

## 수정
- `GOOGLE_WEB_CLIENT_ID` 환경변수 추가
- `_verify_google_token`의 audiences 목록에 포함

## 배포 전 필수
서버 `.env`에 아래 값 추가:
```
GOOGLE_WEB_CLIENT_ID=672840096126-eo1g05o7l02tt7fhdb81hlq4nresk6bl.apps.googleusercontent.com
```

## Test plan
- [ ] 웹에서 구글 로그인 정상 동작 확인
- [ ] 앱에서 구글 로그인 정상 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)