### PR TITLE
fix: 회원가입 시 UserCreate height/weight 필수 검증 제거

### DIFF
--- a/app/users/schemas.py
+++ b/app/users/schemas.py
@@ -7,8 +7,8 @@ class UserCreate(BaseModel):
     email: EmailStr
     password: str
     nickname: str
-    height: float = Field(ge=50, le=250)
-    weight: float = Field(ge=20, le=300)
+    height: Optional[float] = Field(default=None, ge=50, le=250)
+    weight: Optional[float] = Field(default=None, ge=20, le=300)
 
     @field_validator("password")
     @classmethod


### PR DESCRIPTION
프론트 회원가입 화면은 height/weight를 받지 않고 initial-q 단계에서 별도 수집하는데, UserCreate 스키마가 두 필드를 필수로 요구해 /auth/signup 요청이 항상 422로 실패하고 있었음.